### PR TITLE
use parent pom 6.8.0-SNAPSHOT so master is...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>maven-parent-pom</artifactId>
         <groupId>org.eclipse.che.parent</groupId>
-        <version>6.7.0-SNAPSHOT</version>
+        <version>6.8.0-SNAPSHOT</version>
         <relativePath />
     </parent>
     <groupId>org.eclipse.che.dev</groupId>


### PR DESCRIPTION
use parent pom 6.8.0-SNAPSHOT so master is consistent for che-parent, che-dev, che-dependencies, and che

Change-Id: Ia19f7d1b66dec40621dc5175339635061e8aad02
Signed-off-by: nickboldt <nboldt@redhat.com>