### PR TITLE
Make che-dev independent from che-parent + 16v release

### DIFF
--- a/che-codestyle/pom.xml
+++ b/che-codestyle/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-dev-resources-parent</artifactId>
         <groupId>org.eclipse.che.dev</groupId>
-        <version>16</version>
+        <version>17-SNAPSHOT</version>
     </parent>
     <artifactId>che-codestyle</artifactId>
     <packaging>jar</packaging>

--- a/che-eclipse-license-resource-bundle/pom.xml
+++ b/che-eclipse-license-resource-bundle/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-dev-resources-parent</artifactId>
         <groupId>org.eclipse.che.dev</groupId>
-        <version>16</version>
+        <version>17-SNAPSHOT</version>
     </parent>
     <artifactId>che-eclipse-license-resource-bundle</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.che.dev</groupId>
     <artifactId>che-dev-resources-parent</artifactId>
-    <version>16</version>
+    <version>17-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Development Resources for Eclipse Che projects</name>
     <modules>
@@ -25,7 +25,7 @@
     <scm>
         <connection>scm:git:git://github.com/eclipse/che-dev.git</connection>
         <developerConnection>scm:git:git@github.com:eclipse/che-dev.git</developerConnection>
-        <tag>16</tag>
+        <tag>HEAD</tag>
         <url>https://github.com/eclipse/che-dev</url>
     </scm>
     <repositories>


### PR DESCRIPTION
### What does this PR do?
Make che-dev independent from che-parent.

### What issues does this PR fix or reference?
Related to https://github.com/eclipse/che/issues/10170
