### PR TITLE
Provide license years using license-maven-plugin-git extension

### DIFF
--- a/che-eclipse-license-resource-bundle/src/main/resources/license-header.txt
+++ b/che-eclipse-license-resource-bundle/src/main/resources/license-header.txt
@@ -1,4 +1,4 @@
-Copyright (c) ${h_license_years} ${h_copyrightOwner}
+Copyright (c) ${license.git.copyrightYears} ${h_copyrightOwner}
 This program and the accompanying materials are made
 available under the terms of the Eclipse Public License 2.0
 which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/che-eclipse-license-resource-bundle/src/main/resources/license-header2.txt
+++ b/che-eclipse-license-resource-bundle/src/main/resources/license-header2.txt
@@ -1,4 +1,4 @@
-Copyright (c) ${h_license_years} ${h_copyrightOwner}
+Copyright (c) ${license.git.copyrightYears} ${h_copyrightOwner}
 This program and the accompanying materials are made
 available under the terms of the Eclipse Public License 2.0
 which is available at https://www.eclipse.org/legal/epl-2.0/


### PR DESCRIPTION
Use ${license.git.copyrightYears} to determine years in license headers

More info at https://github.com/eclipse/che-parent/pull/97